### PR TITLE
For composition of commands, `Run` handler can argue multiple types.

### DIFF
--- a/cmd/peer/main.go
+++ b/cmd/peer/main.go
@@ -17,6 +17,7 @@ func main() {
 	//console.RegisterBlockchain(bc, core.AppendBlockchain)
 	//console.RegisterBlock(core.NewBlock)
 	execute.BlockchainCommands()
+	execute.ConsensusCommands()
 	RegisterCommand()
 	console.Start()
 }
@@ -25,10 +26,11 @@ func main() {
 func RegisterCommand() {
 	_ = command.AddCommand("", command.Command{
 		Name:        "quit",
+		ShortName:   "q",
 		Description: "Exit the program",
 		Commands:    nil,
 		Flags:       nil,
-		Run: func(args []string) error {
+		Run: func() error {
 			console.GetContext().Quit()
 			return nil
 		},

--- a/execute/consensus.go
+++ b/execute/consensus.go
@@ -1,6 +1,9 @@
 package execute
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/smartm2m/chainutil/console/command"
 	"github.com/smartm2m/chainutil/log"
 )
@@ -9,27 +12,46 @@ import (
 func ConsensusCommands() {
 	_ = command.AddCommand("", command.Command{
 		Name:        "consensus",
+		ShortName:   "c",
 		Description: "manage consensus",
 		Commands: []command.Command{
 			command.Command{
 				Name:        "perform",
+				ShortName:   "p",
 				Description: "perform a consensus algorithm.",
 				Commands:    nil,
 				Flags:       nil,
 				Run:         PerformConsensus,
 			},
+			command.Command{
+				Name:        "execute",
+				ShortName:   "e",
+				Description: "execute a test.",
+				Commands:    nil,
+				Flags:       nil,
+				Run:         Execution,
+			},
 		},
 		Flags: nil,
-		Run: func(args []string) error {
-			log.Debug("Consensus commands")
-
-			return nil
-		},
+		Run:   nil,
 	})
 }
 
 // PerformConsensus performs consensus for blockchains.
-func PerformConsensus(args []string) error {
-	log.Debug("consensus perform")
+func PerformConsensus(p1, p2, p3 string) error {
+	res := fmt.Sprintf("PerformConsensus(%s,%s,%s)", p1, p2, p3)
+	log.Debug(res)
+
+	if p1 == "2" {
+		return nil
+	}
+
+	return errors.New("asdf")
+}
+
+// Execution ...
+func Execution(p1 string, p2 int, p3 uint64, p4 int64, p5 []byte) error {
+	res := fmt.Sprintf("Execution(%s,%v,%v,%v,%v)", p1, p2, p3, p4, p5)
+	log.Debug(res)
 	return nil
 }


### PR DESCRIPTION
  - `ShortName` was added.
  - `help` in console will display all commands with indent.
  - `Run` handler can argu multiple types of parameters.