### PR TITLE
Default parameter option was used in blockchain.

### DIFF
--- a/execute/blockchain.go
+++ b/execute/blockchain.go
@@ -46,8 +46,9 @@ func BlockchainCommands() {
 						Run:         ShowBlockchainsInformationAll,
 					},
 				},
-				Flags: nil,
-				Run:   ShowBlockchainInformation,
+				Flags:         nil,
+				DefaultParams: []interface{}{uint64(1)},
+				Run:           ShowBlockchainInformation,
 			},
 			command.Command{
 				Name:        "block",


### PR DESCRIPTION
  - `chainutil` was updated to support to describe default parameters.
  - `blockchain info` command add a default parameter.